### PR TITLE
feat: app theme init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * feat: app typography
 * feat: server error interceptor
+* feat: app theme
 
 ## 0.0.0+2
 

--- a/lib/src/core/ui/res/colors/project_colors.dart
+++ b/lib/src/core/ui/res/colors/project_colors.dart
@@ -1,28 +1,48 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 abstract class ProjectColors {
-  static const Color whiteColor = _white;
-  static const Color divider = _grey;
-  static const Color shadow = _grey;
-  static const Color disabledColor = _darkGrey;
-  static const Color colorError = _freeSpeechRed;
-  static const Color primaryColor = _brightBlue;
-  static const Color activeColor = _green;
-  static const Color textFieldColor = _brightGrey;
-  static const Color secondaryColor = _dustyBlue;
+  static const ColorScheme lightColorScheme = ColorScheme(
+    background: ProjectColors.backgroundColor,
+    brightness: Brightness.light,
+    error: ProjectColors.errorColor,
+    onBackground: ProjectColors.onBackgroundColor,
+    onError: ProjectColors.onErrorColor,
+    onPrimary: ProjectColors.onPrimaryColor,
+    onSecondary: ProjectColors.onSecondaryColor,
+    onSurface: ProjectColors.onSurfaceColor,
+    primary: ProjectColors.primaryColor,
+    primaryVariant: ProjectColors.primaryColor,
+    secondary: ProjectColors.secondaryColor,
+    secondaryVariant: ProjectColors.secondaryColor,
+    surface: ProjectColors.surfaceColor,
+  );
+
+  static const Color backgroundColor = _white;
+  static const Color surfaceColor = _white;
+  static const Color shadowColor = _darkGrey;
+  static const Color errorColor = _red;
+  static const Color primaryColor = _yellow;
+  static const Color secondaryColor = _blue;
   static const Color textColorPrimary = _black;
+  // OnError - текст на цвете ошибки, в схеме его нет - поставил белый
+  static const Color onErrorColor = _white;
+  static const Color onPrimaryColor = _black;
+  static const Color onSecondaryColor = _white;
+  static const Color onSurfaceColor = _black;
+  static const Color onBackgroundColor = _black;
 
-// TODO(any): Основная палитра
+  static const Color cardColor = _salad;
+  static const Color accentColor = _lightSalad;
+  static const Color borderColor = _lightSalad;
+  static const Color progressStatusColor = _orange;
 
+  static const Color _black = Color(0xFF000000);
+  static const Color _blue = Color(0xFF184E9E);
+  static const Color _darkGrey = Color(0xCC000000);
+  static const Color _lightSalad = Color(0xFFB8F09D);
+  static const Color _orange = Color(0xFFED863A);
+  static const Color _red = Color(0xFFB00020);
+  static const Color _salad = Color(0xFFA9D899);
   static const Color _white = Color(0xFFFFFFFF);
-  static const Color _grey = Color(0xFFDFDFDF);
-  static const Color _freeSpeechRed = Color(0xFFE63946);
-  static const Color _darkGrey = Color(0xFF818C99);
-  static const Color _brightBlue = Color(0xFF457B9D);
-  static const Color _green = Color(0xFF90BE6D);
-  static const Color _brightGrey = Color(0xFFEBEDF0);
-  static const Color _dustyBlue = Color(0xFFA8DADC);
-  static const Color _black = Color(0xFF242424);
+  static const Color _yellow = Color(0xFFEBCE0C);
 }

--- a/lib/src/core/ui/uikit/progress_icon_widget.dart
+++ b/lib/src/core/ui/uikit/progress_icon_widget.dart
@@ -24,8 +24,7 @@ class ProgressIconWidget extends StatelessWidget {
           CircularProgressIndicator(
             value: progress,
             strokeWidth: 1.0,
-            color: ProjectColors.activeColor,
-            backgroundColor: ProjectColors.divider,
+            backgroundColor: ProjectColors.backgroundColor,
           ),
           if (progress < 1)
             Text(
@@ -39,7 +38,7 @@ class ProgressIconWidget extends StatelessWidget {
             const Center(
               child: Icon(
                 Icons.check,
-                color: ProjectColors.activeColor,
+                color: ProjectColors.secondaryColor,
                 size: 16.0,
               ),
             ),

--- a/lib/src/features/app/ui/app.dart
+++ b/lib/src/features/app/ui/app.dart
@@ -32,7 +32,8 @@ class _AppState extends State<App> with ViewModelDisposerMixin<App, AppVm> {
       animation: vm,
       builder: (context, child) {
         return MaterialApp.router(
-          scaffoldMessengerKey: context.read<AppDependencies>().messageController.scaffoldKey,
+          scaffoldMessengerKey:
+              context.read<AppDependencies>().messageController.scaffoldKey,
           routerDelegate: RoutemasterDelegate(
             routesBuilder: (_) => AppRouter.routes,
           ),

--- a/lib/src/features/app/ui/app.dart
+++ b/lib/src/features/app/ui/app.dart
@@ -7,6 +7,7 @@ import 'package:where_to_go_today/src/core/ui/base/view_model_disposer_mixin.dar
 import 'package:where_to_go_today/src/di/app_dependencies.dart';
 import 'package:where_to_go_today/src/features/app/ui/app_vm.dart';
 import 'package:where_to_go_today/src/navigation/app_router.dart';
+import 'package:where_to_go_today/src/res/theme/app_theme.dart';
 
 /// The Widget that configures your application.
 class App extends StatefulWidget {
@@ -31,8 +32,7 @@ class _AppState extends State<App> with ViewModelDisposerMixin<App, AppVm> {
       animation: vm,
       builder: (context, child) {
         return MaterialApp.router(
-          scaffoldMessengerKey:
-              context.read<AppDependencies>().messageController.scaffoldKey,
+          scaffoldMessengerKey: context.read<AppDependencies>().messageController.scaffoldKey,
           routerDelegate: RoutemasterDelegate(
             routesBuilder: (_) => AppRouter.routes,
           ),
@@ -50,7 +50,7 @@ class _AppState extends State<App> with ViewModelDisposerMixin<App, AppVm> {
             Locale('RU', ''), // Russia, no country code
           ],
           onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-          theme: ThemeData(),
+          theme: AppTheme.lightTheme,
           darkTheme: ThemeData.dark(),
           themeMode: widget.vm.themeMode,
         );

--- a/lib/src/res/theme/app_theme.dart
+++ b/lib/src/res/theme/app_theme.dart
@@ -79,6 +79,9 @@ class AppTheme {
             ? ProjectColors.onPrimaryColor.withAlpha(130)
             : ProjectColors.onPrimaryColor,
       ),
+      overlayColor: MaterialStateProperty.all(
+        ProjectColors.secondaryColor.withOpacity(0.1),
+      ),
       padding: MaterialStateProperty.all(
         const EdgeInsets.symmetric(horizontal: 16),
       ),

--- a/lib/src/res/theme/app_theme.dart
+++ b/lib/src/res/theme/app_theme.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:where_to_go_today/src/core/ui/res/colors/project_colors.dart';
+import 'package:where_to_go_today/src/core/ui/res/typography/app_typography.dart';
+
+class AppTheme {
+  static const _appBarTheme = AppBarTheme(
+    backgroundColor: Colors.transparent,
+    elevation: 0.0,
+  );
+
+  static const _bottomNavigationBarTheme = BottomNavigationBarThemeData(
+    selectedItemColor: ProjectColors.secondaryColor,
+    unselectedItemColor: ProjectColors.onBackgroundColor,
+    selectedLabelStyle: AppTypography.s12w400h20(),
+    unselectedLabelStyle: AppTypography.s12w400h20(),
+  );
+
+  static const _cardTheme = CardTheme(
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(
+        Radius.circular(10.0),
+      ),
+    ),
+  );
+
+  static const _inputDecorationTheme = InputDecorationTheme(
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.all(
+        Radius.circular(6.0),
+      ),
+      borderSide: BorderSide(
+        color: ProjectColors.secondaryColor,
+      ),
+    ),
+    contentPadding: EdgeInsets.all(16.0),
+    enabledBorder: OutlineInputBorder(
+      borderSide: BorderSide(
+        color: ProjectColors.secondaryColor,
+      ),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderSide: BorderSide(
+        color: ProjectColors.secondaryColor,
+      ),
+      borderRadius: BorderRadius.all(
+        Radius.circular(6.0),
+      ),
+    ),
+    labelStyle: AppTypography.s16w400h20(),
+  );
+
+  static const _progressIndicatorTheme = ProgressIndicatorThemeData(
+    color: ProjectColors.secondaryColor,
+  );
+
+  static const _textSelectionTheme = TextSelectionThemeData(
+    cursorColor: ProjectColors.secondaryColor,
+  );
+
+  static final _checkboxTheme = CheckboxThemeData(
+    checkColor: MaterialStateProperty.all(
+      ProjectColors.onSecondaryColor,
+    ),
+    fillColor: MaterialStateProperty.all(
+      ProjectColors.secondaryColor,
+    ),
+  );
+
+  static final _textButtonTheme = TextButtonThemeData(
+    style: ButtonStyle(
+      backgroundColor: MaterialStateProperty.all(
+        ProjectColors.primaryColor,
+      ),
+      fixedSize: MaterialStateProperty.all(
+        const Size(double.infinity, 46),
+      ),
+      foregroundColor: MaterialStateProperty.resolveWith(
+        (states) => states.contains(MaterialState.disabled)
+            ? ProjectColors.onPrimaryColor.withAlpha(130)
+            : ProjectColors.onPrimaryColor,
+      ),
+      padding: MaterialStateProperty.all(
+        const EdgeInsets.symmetric(horizontal: 16),
+      ),
+      shape: MaterialStateProperty.all(
+        const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(
+            Radius.circular(12.0),
+          ),
+          side: BorderSide(color: ProjectColors.secondaryColor),
+        ),
+      ),
+    ),
+  );
+
+  static final _switchTheme = SwitchThemeData(
+    thumbColor: MaterialStateProperty.all(
+      ProjectColors.primaryColor,
+    ),
+    trackColor: MaterialStateProperty.all(
+      ProjectColors.onBackgroundColor,
+    ),
+  );
+
+  static ThemeData get lightTheme {
+    return ThemeData(
+      appBarTheme: _appBarTheme,
+      bottomNavigationBarTheme: _bottomNavigationBarTheme,
+      cardTheme: _cardTheme,
+      colorScheme: ProjectColors.lightColorScheme,
+      checkboxTheme: _checkboxTheme,
+      inputDecorationTheme: _inputDecorationTheme,
+      progressIndicatorTheme: _progressIndicatorTheme,
+      switchTheme: _switchTheme,
+      textButtonTheme: _textButtonTheme,
+      textSelectionTheme: _textSelectionTheme,
+      textTheme: const TextTheme(
+        headline2: AppTypography.s24w600h20(),
+        bodyText2: AppTypography.s18w500h20ls(),
+        bodyText1: AppTypography.s16w500h20ls(),
+        subtitle1: AppTypography.s16w500h20(),
+        caption: AppTypography.s16w400h20(),
+        button: AppTypography.s16w500h20(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Ссылка на задачу
Задача #1 

# Что было сделано

• Добавлен класс AppTheme с геттером для светлой темы lightTheme в lib/src/res/theme/app_theme.dart
• Установлены базовые стили для полей ввода, текстовых кнопок, индикатора прогресса, карточек, чекбоксов, свитчей, appBar и bottomNavigationBar
• Обновлен класс ProjectColors в соответствии с макетом
• Подключена типография в теме
• Подключена тема в app.dart

# Как проверить работу?

Можно заметить при запуске приложения:
• Изменена схема цветов по всему приложению
• Стили для уже имеющихся виджетов: AppBar, BottomNavigationBar
• Шрифты на страницах

# Чек-лист

- [x] Функциональность протестирована и работает корректно
- [x] Если в задаче есть верстка - прикреплен скриншот или запись экрана

![Image002](https://user-images.githubusercontent.com/62483370/150990732-6fa2cd1c-590d-467a-8785-9f1657e3bf8a.jpg)