### PR TITLE
feat: SignInScreenVm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0
 
+- feat: SignInScreenVm
 - fix: iOS build support
 - feat: auth repository
 - feat: phone auth service

--- a/lib/src/core/services/exceptions/server/server_error_exception.dart
+++ b/lib/src/core/services/exceptions/server/server_error_exception.dart
@@ -15,5 +15,8 @@ class ImageSoLargeException implements Exception {}
 /// Ошибка при протухшем токене
 class UnauthorizedException implements Exception {}
 
+/// Ошибка при авторизации
+class AuthorizationException implements Exception {}
+
 /// Ошибка при наличии у пользователя активной сессии
 class ActiveSessionException implements Exception {}

--- a/lib/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart
+++ b/lib/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart
@@ -31,6 +31,8 @@ class SnackBarErrorScenarios implements ErrorScenario {
       // TODO(any): добавить новые исключения и соспоставить им текст ошибки
       NotFoundException: () =>
           messageController.show(ErrorSnackBar('Not found')),
+      AuthorizationException: () => messageController
+          .show(ErrorSnackBar('Авторизация не удалась! Попробуйте еще раз')),
     };
   }
 

--- a/lib/src/di/app_dependencies.dart
+++ b/lib/src/di/app_dependencies.dart
@@ -4,11 +4,14 @@ import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_han
 import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart';
 import 'package:where_to_go_today/src/core/ui/messages/default_message_controller.dart';
 import 'package:where_to_go_today/src/features/auth/services/storage/token_storage.dart';
+import 'package:where_to_go_today/src/features/authservices/api/auth_api.dart';
+import 'package:where_to_go_today/src/features/authservices/repository/auth_repository.dart';
 import 'package:where_to_go_today/src/features/settings/service/event/settings_event.dart';
 import 'package:where_to_go_today/src/features/settings/service/repository/settings_repository.dart';
 import 'package:where_to_go_today/src/features/settings/service/settings_bloc.dart';
 
 import '../core/services/network/firebase_options.dart';
+import '../features/auth/services/auth_bloc.dart';
 import 'base/dependency_bundle.dart';
 
 /// Класс с глобальными зависимостями приложения
@@ -17,6 +20,9 @@ class AppDependencies extends DependencyBundle {
   final dio = DioModule().dio;
   final settingsController = SettingsBloc(SettingsRepository());
   final tokenStorage = TokenStorage();
+
+  late final authRepository = AuthRepository(AuthApi(dio));
+  late final authBloc = AuthBloc(authRepository: authRepository);
 
   late final messageController = DefaultMessageController();
   late final errorHandler = ScenarioErrorHandler(

--- a/lib/src/features/auth/services/auth_bloc.dart
+++ b/lib/src/features/auth/services/auth_bloc.dart
@@ -1,6 +1,8 @@
 import 'package:bloc/bloc.dart';
+import 'package:where_to_go_today/src/core/services/base/can_throw_exception_bloc_mixin.dart';
 import 'package:where_to_go_today/src/features/auth/services/bloc/events/auth_event.dart';
 import 'package:where_to_go_today/src/features/auth/services/bloc/states/auth_state.dart';
+import 'package:where_to_go_today/src/features/authservices/repository/auth_repository.dart';
 
 /// Сервис позволяющий:
 ///   - обработать номер телефона пользователя
@@ -9,10 +11,13 @@ import 'package:where_to_go_today/src/features/auth/services/bloc/states/auth_st
 ///   - провести заполнение данных профиля при регистрации
 ///   - произвести логаут
 ///
-class AuthBloc extends Bloc<AuthEvent, AuthState> {
+class AuthBloc extends Bloc<AuthEvent, AuthState>
+    with CanThrowExceptionBlocMixin {
+  final AuthRepository authRepository;
+
   bool firstSending = true;
 
-  AuthBloc() : super(const AuthState.init()) {
+  AuthBloc({required this.authRepository}) : super(const AuthState.init()) {
     on<AuthEventSendPhone>((event, emit) async {
       if (firstSending) {
         emit(const AuthState.idle());
@@ -44,10 +49,17 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       emit(const AuthState.success());
     });
 
+    // Пример обработчика в блоке
     on<AuthEventLoginViaGoogle>((event, emit) async {
-      emit(const AuthState.idle());
-      // TODO(any): handle incoming `AuthEventLoginViaGoogle` event
-      emit(const AuthState.success());
+      try {
+        emit(const AuthState.idle());
+
+        // TODO(Denis): отправить запрос в сервис google и передать токен в репозиторий
+
+        emit(const AuthState.success());
+      } on Exception catch (e, s) {
+        emit(AuthState.error(e, s));
+      }
     });
 
     on<AuthEventRegister>((event, emit) async {

--- a/lib/src/features/auth/services/bloc/states/auth_state.dart
+++ b/lib/src/features/auth/services/bloc/states/auth_state.dart
@@ -12,6 +12,9 @@ class AuthState with _$AuthState {
 
   const factory AuthState.success() = AuthStateSuccess;
 
-  // ignore: avoid_annotating_with_dynamic
-  const factory AuthState.error(dynamic error) = AuthStateError;
+  const factory AuthState.error(
+    // ignore: avoid_annotating_with_dynamic
+    dynamic error,
+    StackTrace stackTrace,
+  ) = AuthStateError;
 }

--- a/lib/src/features/auth/services/bloc/states/auth_state.freezed.dart
+++ b/lib/src/features/auth/services/bloc/states/auth_state.freezed.dart
@@ -33,9 +33,10 @@ class _$AuthStateTearOff {
     return const AuthStateSuccess();
   }
 
-  AuthStateError error(dynamic error) {
+  AuthStateError error(dynamic error, StackTrace stackTrace) {
     return AuthStateError(
       error,
+      stackTrace,
     );
   }
 }
@@ -51,7 +52,7 @@ mixin _$AuthState {
     required TResult Function() needOtp,
     required TResult Function() idle,
     required TResult Function() success,
-    required TResult Function(dynamic error) error,
+    required TResult Function(dynamic error, StackTrace stackTrace) error,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -60,7 +61,7 @@ mixin _$AuthState {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -69,7 +70,7 @@ mixin _$AuthState {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -162,7 +163,7 @@ class _$AuthStateInit implements AuthStateInit {
     required TResult Function() needOtp,
     required TResult Function() idle,
     required TResult Function() success,
-    required TResult Function(dynamic error) error,
+    required TResult Function(dynamic error, StackTrace stackTrace) error,
   }) {
     return init();
   }
@@ -174,7 +175,7 @@ class _$AuthStateInit implements AuthStateInit {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
   }) {
     return init?.call();
   }
@@ -186,7 +187,7 @@ class _$AuthStateInit implements AuthStateInit {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
     required TResult orElse(),
   }) {
     if (init != null) {
@@ -284,7 +285,7 @@ class _$AuthStateNeedOtp implements AuthStateNeedOtp {
     required TResult Function() needOtp,
     required TResult Function() idle,
     required TResult Function() success,
-    required TResult Function(dynamic error) error,
+    required TResult Function(dynamic error, StackTrace stackTrace) error,
   }) {
     return needOtp();
   }
@@ -296,7 +297,7 @@ class _$AuthStateNeedOtp implements AuthStateNeedOtp {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
   }) {
     return needOtp?.call();
   }
@@ -308,7 +309,7 @@ class _$AuthStateNeedOtp implements AuthStateNeedOtp {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
     required TResult orElse(),
   }) {
     if (needOtp != null) {
@@ -406,7 +407,7 @@ class _$AuthStateIdle implements AuthStateIdle {
     required TResult Function() needOtp,
     required TResult Function() idle,
     required TResult Function() success,
-    required TResult Function(dynamic error) error,
+    required TResult Function(dynamic error, StackTrace stackTrace) error,
   }) {
     return idle();
   }
@@ -418,7 +419,7 @@ class _$AuthStateIdle implements AuthStateIdle {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
   }) {
     return idle?.call();
   }
@@ -430,7 +431,7 @@ class _$AuthStateIdle implements AuthStateIdle {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
     required TResult orElse(),
   }) {
     if (idle != null) {
@@ -528,7 +529,7 @@ class _$AuthStateSuccess implements AuthStateSuccess {
     required TResult Function() needOtp,
     required TResult Function() idle,
     required TResult Function() success,
-    required TResult Function(dynamic error) error,
+    required TResult Function(dynamic error, StackTrace stackTrace) error,
   }) {
     return success();
   }
@@ -540,7 +541,7 @@ class _$AuthStateSuccess implements AuthStateSuccess {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
   }) {
     return success?.call();
   }
@@ -552,7 +553,7 @@ class _$AuthStateSuccess implements AuthStateSuccess {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
     required TResult orElse(),
   }) {
     if (success != null) {
@@ -611,7 +612,7 @@ abstract class $AuthStateErrorCopyWith<$Res> {
   factory $AuthStateErrorCopyWith(
           AuthStateError value, $Res Function(AuthStateError) then) =
       _$AuthStateErrorCopyWithImpl<$Res>;
-  $Res call({dynamic error});
+  $Res call({dynamic error, StackTrace stackTrace});
 }
 
 /// @nodoc
@@ -627,12 +628,17 @@ class _$AuthStateErrorCopyWithImpl<$Res> extends _$AuthStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? error = freezed,
+    Object? stackTrace = freezed,
   }) {
     return _then(AuthStateError(
       error == freezed
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
               as dynamic,
+      stackTrace == freezed
+          ? _value.stackTrace
+          : stackTrace // ignore: cast_nullable_to_non_nullable
+              as StackTrace,
     ));
   }
 }
@@ -640,14 +646,16 @@ class _$AuthStateErrorCopyWithImpl<$Res> extends _$AuthStateCopyWithImpl<$Res>
 /// @nodoc
 
 class _$AuthStateError implements AuthStateError {
-  const _$AuthStateError(this.error);
+  const _$AuthStateError(this.error, this.stackTrace);
 
-  @override
+  @override // ignore: avoid_annotating_with_dynamic
   final dynamic error;
+  @override
+  final StackTrace stackTrace;
 
   @override
   String toString() {
-    return 'AuthState.error(error: $error)';
+    return 'AuthState.error(error: $error, stackTrace: $stackTrace)';
   }
 
   @override
@@ -655,12 +663,16 @@ class _$AuthStateError implements AuthStateError {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is AuthStateError &&
-            const DeepCollectionEquality().equals(other.error, error));
+            const DeepCollectionEquality().equals(other.error, error) &&
+            const DeepCollectionEquality()
+                .equals(other.stackTrace, stackTrace));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(error),
+      const DeepCollectionEquality().hash(stackTrace));
 
   @JsonKey(ignore: true)
   @override
@@ -674,9 +686,9 @@ class _$AuthStateError implements AuthStateError {
     required TResult Function() needOtp,
     required TResult Function() idle,
     required TResult Function() success,
-    required TResult Function(dynamic error) error,
+    required TResult Function(dynamic error, StackTrace stackTrace) error,
   }) {
-    return error(this.error);
+    return error(this.error, stackTrace);
   }
 
   @override
@@ -686,9 +698,9 @@ class _$AuthStateError implements AuthStateError {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
   }) {
-    return error?.call(this.error);
+    return error?.call(this.error, stackTrace);
   }
 
   @override
@@ -698,11 +710,11 @@ class _$AuthStateError implements AuthStateError {
     TResult Function()? needOtp,
     TResult Function()? idle,
     TResult Function()? success,
-    TResult Function(dynamic error)? error,
+    TResult Function(dynamic error, StackTrace stackTrace)? error,
     required TResult orElse(),
   }) {
     if (error != null) {
-      return error(this.error);
+      return error(this.error, stackTrace);
     }
     return orElse();
   }
@@ -749,9 +761,12 @@ class _$AuthStateError implements AuthStateError {
 }
 
 abstract class AuthStateError implements AuthState {
-  const factory AuthStateError(dynamic error) = _$AuthStateError;
+  const factory AuthStateError(dynamic error, StackTrace stackTrace) =
+      _$AuthStateError;
 
+// ignore: avoid_annotating_with_dynamic
   dynamic get error;
+  StackTrace get stackTrace;
   @JsonKey(ignore: true)
   $AuthStateErrorCopyWith<AuthStateError> get copyWith =>
       throw _privateConstructorUsedError;

--- a/lib/src/features/auth/sign_in/sign_in_route.dart
+++ b/lib/src/features/auth/sign_in/sign_in_route.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:where_to_go_today/src/di/app_dependencies.dart';
+import 'package:where_to_go_today/src/features/auth/sign_in/sign_in_screen.dart';
+import 'package:where_to_go_today/src/features/auth/sign_in/sign_in_screen_vm.dart';
+
+/// Маршрут для навигации к экрану авторизации
+class SignInRoute extends MaterialPage<void> {
+  static const routeName = '/signIn';
+
+  SignInRoute()
+      : super(
+          child: Provider<SignInScreenVm>(
+            create: (ctx) => SignInScreenVm(
+              ctx.read<AppDependencies>().authBloc,
+              errorHandler: ctx.read<AppDependencies>().errorHandler,
+              context: ctx,
+            ),
+            child: Builder(
+              builder: (context) {
+                return SignInScreen(
+                  vm: context.read<SignInScreenVm>(),
+                );
+              },
+            ),
+          ),
+        );
+}

--- a/lib/src/features/auth/sign_in/sign_in_screen.dart
+++ b/lib/src/features/auth/sign_in/sign_in_screen.dart
@@ -1,19 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
-import 'package:where_to_go_today/src/features/auth/sign_in/sotial_login_button.dart';
+import 'package:where_to_go_today/src/core/ui/base/view_model_disposer_mixin.dart';
+import 'package:where_to_go_today/src/features/auth/sign_in/sign_in_screen_vm.dart';
+import 'package:where_to_go_today/src/features/auth/sign_in/social_login_button.dart';
 import 'package:where_to_go_today/src/localization/l10n.dart';
 import 'package:where_to_go_today/src/res/asset.dart';
 import 'package:where_to_go_today/src/ui/uikit/wtgt_button.dart';
 
 class SignInScreen extends StatefulWidget {
-  const SignInScreen({Key? key}) : super(key: key);
+  final SignInScreenVm vm;
+
+  const SignInScreen({Key? key, required this.vm}) : super(key: key);
 
   @override
   State<SignInScreen> createState() => _SignInScreenState();
 }
 
-class _SignInScreenState extends State<SignInScreen> {
+class _SignInScreenState extends State<SignInScreen>
+    with ViewModelDisposerMixin<SignInScreen, SignInScreenVm> {
   late final MaskTextInputFormatter _maskFormatter;
+
+  @override
+  SignInScreenVm get vm => widget.vm;
+
   late bool _isValidPhone;
 
   @override
@@ -31,51 +41,53 @@ class _SignInScreenState extends State<SignInScreen> {
       child: Scaffold(
         body: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-          child: Column(
-            children: [
-              Image.asset(
-                Asset.png.logoWtgt,
-                height: 254,
-              ),
-              const SizedBox(height: 22),
-              TextField(
-                onChanged: (_) => _validatePhone(),
-                decoration: InputDecoration(
-                  labelText: context.l10n.phoneNumberLabel,
-                  prefixText: '+7 ',
-                  hintText: '(XXX) XXX-XX-XX',
+          child: Observer(
+            builder: (_) => Column(
+              children: [
+                Image.asset(
+                  Asset.png.logoWtgt,
+                  height: 254,
                 ),
-                keyboardType: TextInputType.number,
-                inputFormatters: [
-                  _maskFormatter,
-                ],
-              ),
-              const SizedBox(height: 32),
-              WtgtButton(
-                label: context.l10n.sendButtonLabel,
-                onPressed: _isValidPhone ? _onSendCode : null,
-              ),
-              SizedBox(
-                height: _calcBottomPadding(),
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  SotialLoginButton(
-                    imageAsset: Asset.svg.iconFacebook,
-                    onPressed: _onFacebookLogin,
+                const SizedBox(height: 22),
+                TextField(
+                  onChanged: (_) => _validatePhone(),
+                  decoration: InputDecoration(
+                    labelText: context.l10n.phoneNumberLabel,
+                    prefixText: '+7 ',
+                    hintText: '(XXX) XXX-XX-XX',
                   ),
-                  SotialLoginButton(
-                    imageAsset: Asset.svg.iconVkontakte,
-                    onPressed: _onVkontakteLogin,
-                  ),
-                  SotialLoginButton(
-                    imageAsset: Asset.svg.iconGoogle,
-                    onPressed: _onGoogleLogin,
-                  ),
-                ],
-              ),
-            ],
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [
+                    _maskFormatter,
+                  ],
+                ),
+                const SizedBox(height: 32),
+                WtgtButton(
+                  label: context.l10n.sendButtonLabel,
+                  onPressed: _isValidPhone ? _onSendCode : null,
+                ),
+                SizedBox(
+                  height: _calcBottomPadding(),
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    SocialLoginButton(
+                      imageAsset: Asset.svg.iconFacebook,
+                      onPressed: _onFacebookLogin,
+                    ),
+                    SocialLoginButton(
+                      imageAsset: Asset.svg.iconVkontakte,
+                      onPressed: _onVkontakteLogin,
+                    ),
+                    SocialLoginButton(
+                      imageAsset: Asset.svg.iconGoogle,
+                      onPressed: vm.signInWithGoogle,
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -107,11 +119,6 @@ class _SignInScreenState extends State<SignInScreen> {
   void _onVkontakteLogin() {
     // TODO(any): обработать нажатие на кнопку
     debugPrint('_onVkontakteLogin()');
-  }
-
-  void _onGoogleLogin() {
-    // TODO(any): обработать нажатие на кнопку
-    debugPrint('_onGoogleLogin()');
   }
 
   void _validatePhone() {

--- a/lib/src/features/auth/sign_in/sign_in_screen_vm.dart
+++ b/lib/src/features/auth/sign_in/sign_in_screen_vm.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:mobx/mobx.dart';
+import 'package:routemaster/routemaster.dart';
+import 'package:where_to_go_today/src/core/services/exceptions/server/server_error_exception.dart';
+import 'package:where_to_go_today/src/core/ui/base/view_model.dart';
+import 'package:where_to_go_today/src/core/ui/errors_handling/error_handler.dart';
+import 'package:where_to_go_today/src/features/auth/services/auth_bloc.dart';
+import 'package:where_to_go_today/src/features/auth/services/bloc/events/auth_event.dart';
+
+import '../services/bloc/states/auth_state.dart';
+
+part 'sign_in_screen_vm.g.dart';
+
+class SignInScreenVm = _SignInScreenVm with _$SignInScreenVm;
+
+abstract class _SignInScreenVm extends ViewModel with Store {
+  final BuildContext context;
+  final AuthBloc _bloc;
+
+  _SignInScreenVm(
+    this._bloc, {
+    required ErrorHandler errorHandler,
+    required this.context,
+  }) : super(errorHandler) {
+    observeBloc<AuthState, AuthBloc>(_bloc, _handleStates);
+  }
+
+  @action
+  void signInWithGoogle() {
+    _bloc.add(const AuthEventLoginViaGoogle());
+  }
+
+  void _handleStates(AuthState state) {
+    if (state is AuthStateSuccess) {
+      Routemaster.of(context).push('/');
+    } else if (state is AuthStateError) {
+      _bloc.onError(AuthorizationException(), state.stackTrace);
+    }
+  }
+}

--- a/lib/src/features/auth/sign_in/sign_in_screen_vm.g.dart
+++ b/lib/src/features/auth/sign_in/sign_in_screen_vm.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sign_in_screen_vm.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_brace_in_string_interps, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars, avoid_as, avoid_annotating_with_dynamic
+
+mixin _$SignInScreenVm on _SignInScreenVm, Store {
+  final _$_SignInScreenVmActionController =
+      ActionController(name: '_SignInScreenVm');
+
+  @override
+  void signInWithGoogle() {
+    final _$actionInfo = _$_SignInScreenVmActionController.startAction(
+        name: '_SignInScreenVm.signInWithGoogle');
+    try {
+      return super.signInWithGoogle();
+    } finally {
+      _$_SignInScreenVmActionController.endAction(_$actionInfo);
+    }
+  }
+
+  @override
+  String toString() {
+    return '''
+
+    ''';
+  }
+}

--- a/lib/src/features/auth/sign_in/social_login_button.dart
+++ b/lib/src/features/auth/sign_in/social_login_button.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-class SotialLoginButton extends StatelessWidget {
+class SocialLoginButton extends StatelessWidget {
   final String imageAsset;
   final VoidCallback? onPressed;
 
-  const SotialLoginButton({
+  const SocialLoginButton({
     Key? key,
     required this.imageAsset,
     this.onPressed,

--- a/lib/src/navigation/app_router.dart
+++ b/lib/src/navigation/app_router.dart
@@ -1,5 +1,5 @@
 import 'package:routemaster/routemaster.dart';
-import 'package:where_to_go_today/src/features/main/main_screen_route.dart';
+import 'package:where_to_go_today/src/features/auth/sign_in/sign_in_route.dart';
 import 'package:where_to_go_today/src/features/settings/ui/settings_route.dart';
 
 /// Класс, в котором описываем навигацию в приложении.
@@ -11,7 +11,8 @@ class AppRouter {
 
   static final routes = RouteMap(
     routes: {
-      initialRoute: (_) => const MainScreenRoute(),
+      // Временно заменил initalRoute для тестирования SignInScreen
+      initialRoute: (_) => SignInRoute(),
       SettingsRoute.routeName: (_) => SettingsRoute(),
     },
   );

--- a/test/auth/auth_bloc_test.dart
+++ b/test/auth/auth_bloc_test.dart
@@ -1,22 +1,33 @@
 // ignore_for_file: cascade_invocations
 import 'package:bloc_test/bloc_test.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:where_to_go_today/src/features/auth/services/auth_bloc.dart';
 import 'package:where_to_go_today/src/features/auth/services/bloc/events/auth_event.dart';
 import 'package:where_to_go_today/src/features/auth/services/bloc/states/auth_state.dart';
+import 'package:where_to_go_today/src/features/authservices/api/auth_api.dart';
+import 'package:where_to_go_today/src/features/authservices/repository/auth_repository.dart';
 
 void main() {
   group('Тесты на блок авторизации', () {
+    late AuthRepository authRepository;
+    late AuthBloc authBloc;
+
+    setUp(() {
+      authRepository = AuthRepository(AuthApi(Dio()));
+      authBloc = AuthBloc(authRepository: authRepository);
+    });
+
     blocTest<AuthBloc, AuthState>(
       'Если отправляем номер телефона, то сначала получаем загрузку, потом состояние с необходимостью подтверждения',
-      build: AuthBloc.new,
+      build: () => authBloc,
       act: (bloc) => bloc.add(const AuthEvent.sendPhone('')),
       expect: () => [const AuthState.idle(), const AuthState.needOtp()],
     );
 
     blocTest<AuthBloc, AuthState>(
       'Если повторно отправляем номер телефона, то сначала получаем загрузку, потом состояние успеха',
-      build: AuthBloc.new,
+      build: () => authBloc,
       act: (bloc) {
         bloc.add(const AuthEvent.sendPhone(''));
         bloc.add(const AuthEvent.sendPhone(''));
@@ -27,21 +38,21 @@ void main() {
 
     blocTest<AuthBloc, AuthState>(
       'Если отправляем смс-код, то сначала получаем загрузку, потом состояние успеха',
-      build: AuthBloc.new,
+      build: () => authBloc,
       act: (bloc) => bloc.add(const AuthEvent.sendOtp('')),
       expect: () => [const AuthState.idle(), const AuthState.success()],
     );
 
     blocTest<AuthBloc, AuthState>(
       'Если отправляем событие входа через соц.сеть, то сначала получаем загрузку, потом состояние успеха',
-      build: AuthBloc.new,
+      build: () => authBloc,
       act: (bloc) => bloc.add(const AuthEvent.loginViaFacebook()),
       expect: () => [const AuthState.idle(), const AuthState.success()],
     );
 
     blocTest<AuthBloc, AuthState>(
       'Если отправляем событие регистрации, то сначала получаем загрузку, потом состояние успеха',
-      build: AuthBloc.new,
+      build: () => authBloc,
       act: (bloc) {
         final birthdate =
             DateTime.now().subtract(const Duration(days: 365 * 18));
@@ -60,7 +71,7 @@ void main() {
 
     blocTest<AuthBloc, AuthState>(
       'Если отправляем событие логаута, то сначала получаем загрузку, потом состояние успеха',
-      build: AuthBloc.new,
+      build: () => authBloc,
       act: (bloc) => bloc.add(const AuthEvent.logout()),
       expect: () => [const AuthState.idle(), const AuthState.success()],
     );


### PR DESCRIPTION
# Задача
ViewModel для экрана SignInScreen

# Что было сделано

- SignInScreenVm с примером обработчика события(signInWithGoogle)
- Использование SignInScreenVm в SignInScreen с помощью миксина ViewModelDisposerMixin
- SignInRoute и использован в AppRouter в качестве initialRoute(для тестов)
- AuthBloc и AuthRepository в AppDependency
- Миксин CanThrowExceptionBlocMixin для ловли ошибок в AuthBloc
- Параметр authRepository в конструкторе AuthBloc
- Шаблон для обработки AuthEventLoginViaGoogle в AuthBloc
- Параметр stackTrace в AuthState.error
- Исправлено название виджета кнопки для соц авторизации(SotialLoginButton -> SocialLoginButton)
