### PR TITLE
feat: onboard storage

### DIFF
--- a/lib/src/di/app_dependencies.dart
+++ b/lib/src/di/app_dependencies.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:where_to_go_today/src/core/services/network/dio/dio_module.dart';
 import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_handler/scenario_error_handler.dart';
 import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart';
@@ -9,6 +10,8 @@ import 'package:where_to_go_today/src/features/auth/services/storage/token_stora
 import 'package:where_to_go_today/src/features/auth/services/vk/vk_auth.dart';
 import 'package:where_to_go_today/src/features/authservices/api/auth_api.dart';
 import 'package:where_to_go_today/src/features/authservices/repository/auth_repository.dart';
+import 'package:where_to_go_today/src/features/onboard/services/repository/onboard_repository.dart';
+import 'package:where_to_go_today/src/features/onboard/services/storage/onboard_storage.dart';
 import 'package:where_to_go_today/src/features/settings/service/event/settings_event.dart';
 import 'package:where_to_go_today/src/features/settings/service/repository/settings_repository.dart';
 import 'package:where_to_go_today/src/features/settings/service/settings_bloc.dart';
@@ -26,6 +29,7 @@ class AppDependencies extends DependencyBundle {
   final tokenStorage = TokenStorage();
   final googleAuth = GoogleAuth();
   late final vkAuth = VKAuth();
+  late final OnboardRepository onboardRepository;
 
   late final authRepository = AuthRepository(AuthApi(dio));
   late final authBloc = AuthBloc(
@@ -43,7 +47,12 @@ class AppDependencies extends DependencyBundle {
 
   Future<void> init() async {
     settingsController.add(LoadSettings());
+    await Hive.initFlutter();
     await tokenStorage.init();
+
+    onboardRepository = OnboardRepository(
+      OnboardStorage(await Hive.openBox<bool>('onboarding')),
+    );
 
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,

--- a/lib/src/features/auth/services/storage/token_storage.dart
+++ b/lib/src/features/auth/services/storage/token_storage.dart
@@ -8,8 +8,6 @@ class TokenStorage {
   late final Box<String> _box;
 
   Future<void> init() async {
-    await Hive.initFlutter();
-
     return openBox(_tokenBox);
   }
 

--- a/lib/src/features/onboard/services/repository/onboard_repository.dart
+++ b/lib/src/features/onboard/services/repository/onboard_repository.dart
@@ -1,0 +1,19 @@
+import 'package:where_to_go_today/src/features/onboard/services/storage/onboard_storage.dart';
+
+class OnboardRepository {
+  final _completedKey = 'completed';
+  final OnboardStorage _onboardStorage;
+
+  OnboardRepository(this._onboardStorage) {
+    final isCompleted = getCompleted();
+
+    if (isCompleted == null) {
+      setCompleted(false);
+    }
+  }
+
+  bool? getCompleted() => _onboardStorage.getValue(_completedKey);
+
+  void setCompleted(bool completed) =>
+      _onboardStorage.storeValue(_completedKey, completed);
+}

--- a/lib/src/features/onboard/services/storage/onboard_storage.dart
+++ b/lib/src/features/onboard/services/storage/onboard_storage.dart
@@ -1,0 +1,11 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+class OnboardStorage {
+  final Box<bool> _box;
+
+  OnboardStorage(this._box);
+
+  void storeValue(String key, bool value) => _box.put(key, value);
+
+  bool? getValue(String key) => _box.get(key);
+}

--- a/test/src/features/onboard/services/repository/onboard_repository_test.dart
+++ b/test/src/features/onboard/services/repository/onboard_repository_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:where_to_go_today/src/features/onboard/services/repository/onboard_repository.dart';
+import 'package:where_to_go_today/src/features/onboard/services/storage/onboard_storage.dart';
+
+class MockOnboardStorage extends Mock implements OnboardStorage {}
+
+void main() {
+  group('Тесты для репозитория onboarding', () {
+    late MockOnboardStorage mockOnboardStorage;
+    late OnboardRepository onboardRepository;
+
+    setUp(() {
+      mockOnboardStorage = MockOnboardStorage();
+      onboardRepository = OnboardRepository(mockOnboardStorage);
+    });
+
+    test('Проверка инициализации completed в конструкторе репозитория', () {
+      verify(() => mockOnboardStorage.storeValue(any(), any())).called(1);
+    });
+
+    test('Метод получения флага completed при первом запуске', () {
+      when(() => mockOnboardStorage.getValue(any())).thenReturn(false);
+      final result = onboardRepository.getCompleted();
+
+      expect(result, false);
+    });
+
+    test('Метод установки флага completed', () {
+      when(() => mockOnboardStorage.storeValue(any(), any())).thenReturn(null);
+
+      onboardRepository.setCompleted(true);
+      verify(() => mockOnboardStorage.storeValue(any(), any())).called(2);
+
+      when(() => mockOnboardStorage.getValue(any())).thenReturn(true);
+
+      final result = onboardRepository.getCompleted();
+
+      expect(result, true);
+    });
+  });
+}

--- a/test/src/features/onboard/services/storage/onboard_storage_test.dart
+++ b/test/src/features/onboard/services/storage/onboard_storage_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:where_to_go_today/src/features/onboard/services/storage/onboard_storage.dart';
+
+void main() {
+  late final OnboardStorage onboardStorage;
+  const completedKey = 'completed';
+
+  group('Тесты хранилища Onboarding', () {
+    setUpAll(() async {
+      final path = Directory.current.path;
+      Hive.init('$path/test/onboard/storage');
+      onboardStorage = OnboardStorage(await Hive.openBox('onboard'));
+    });
+
+    test('Получение флага при первом входе', () {
+      expect(onboardStorage.getValue(completedKey), null);
+    });
+
+    test('Cохранение флага', () {
+      onboardStorage.storeValue(completedKey, false);
+      expect(onboardStorage.getValue(completedKey), false);
+    });
+
+    test('Получение флага при не первом входе', () {
+      expect(onboardStorage.getValue(completedKey), false);
+    });
+
+    tearDownAll(() async {
+      await Hive.deleteFromDisk();
+    });
+  });
+}


### PR DESCRIPTION
# Ссылка на задачу
Задача #60

# Что было сделано

- OnboardStorage - Hive хранилище bool переменных
- OnboardRepository-  репозиторий для получения флага 'completed'
- Вынесена инициализация Hive из TokenStorage в AppDependencies

# Как проверить работу?

- test/src/features/onboard/services/repository/onboard_repository_test.dart - тест репозитория
- test/src/features/onboard/services/storage/onboard_storage_test.dart - тест хранилища

# Чек-лист

- [ ] Функциональность протестирована и работает корректно
